### PR TITLE
Shorten link and remove 500 errors

### DIFF
--- a/twitfix.py
+++ b/twitfix.py
@@ -1,20 +1,30 @@
 from flask import Flask, render_template, url_for, request, redirect
 from datetime import datetime
 import youtube_dl
-import requests
-import psutil
 import os
+import re
 
 ydl = youtube_dl.YoutubeDL({'outtmpl': '%(id)s.%(ext)s'})
 app = Flask(__name__)
+pathregex = re.compile("\\w{1,15}\\/status\\/\\d{19}")
 
 @app.route('/<path:subpath>')
 def twitfix(subpath):
-    if subpath.startswith('https://twitter.com'):
-        with ydl:
-            result = ydl.extract_info(subpath, download=False)
 
-        return render_template('index.html', vidurl=result['url'], tweet=result['description'], pic=result['thumbnail'], user=result['uploader'], tweeturl=subpath)
+    match = pathregex.search(subpath)
+    if match is not None:
+        twitter_url = subpath
+
+        if match.start() == 0:
+            twitter_url = "https://twitter.com/" + subpath
+
+        with ydl:
+            try:
+                result = ydl.extract_info(twitter_url, download=False)
+            except Exception: # Just to keep from 500s that are messy
+                return "Bad twitter link, try again"
+
+        return render_template('index.html', vidurl=result['url'], tweet=result['description'], pic=result['thumbnail'], user=result['uploader'], tweeturl=twitter_url)
     else:
         return "Please use a twitter link"
 

--- a/twitfix.py
+++ b/twitfix.py
@@ -1,7 +1,5 @@
-from flask import Flask, render_template, url_for, request, redirect
-from datetime import datetime
+from flask import Flask, render_template
 import youtube_dl
-import os
 import re
 
 ydl = youtube_dl.YoutubeDL({'outtmpl': '%(id)s.%(ext)s'})


### PR DESCRIPTION
By comparing against a regex we can detect if the link is in the proper format, and allow for excluding `https://twitter.com/" in the url. 
this allows for swapping out `twitter.com` for `twtfix.me` in place, and having the link instantly work.

Also removed some unused imports that were causing issue as they were not in the requires.txt