### PR TITLE
Added fallback links in case automatic forwarding is blocked.

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -10,5 +10,5 @@
 {% endblock %}
 
 {% block body %}
-    You will be redirected to this projects github page in a moment.
+    You will be redirected to this projects github page in a moment. <a href="https://github.com/robinuniverse/TwitFix">Or click here.</a>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,5 +32,5 @@
 {% endblock %}
 
 {% block body %}
-Redirecting you to the tweet...
+Redirecting you to the tweet in a moment. <a href="{{ vidlink }}">Or click here.</a>
 {% endblock %}


### PR DESCRIPTION
When I tried to open a link, I had to manually change the URL from `fxtwitter.com` back to `twitter.com` in order to be redirected to the orignal tweet. So here's a small suggestion to help others who are experiencing the same problem.